### PR TITLE
feat: add outline support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ resources/logo.png
 *.vsix
 images/logo.svg
 todo.md
+
+# macOS
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"publish:ovsx": "ovsx publish --no-dependencies",
 		"publish:vsce": "vsce publish --githubBranch main --no-dependencies",
 		"start": "npm run build:code -- --watch",
-		"test": "echo \"no tests yet\" && exit 0",
+		"test": "vitest run",
 		"vscode:prepublish": "npm run build"
 	},
 	"keywords": [
@@ -460,7 +460,8 @@
 		"sharp-cli": "^5.1.0",
 		"tsdown": "^0.12.6",
 		"typescript": "^5.8.3",
-		"typescript-eslint": "^8.31.1"
+		"typescript-eslint": "^8.31.1",
+		"vitest": "^3.2.4"
 	},
 	"packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,11 @@
 		"vscode": "^1.85.0"
 	},
 	"categories": ["Programming Languages", "Snippets", "Other"],
-	"activationEvents": ["onLanguage:javascript"],
+	"activationEvents": [
+		"onLanguage:javascript",
+		"onLanguage:applescript",
+		"onLanguage:jxa"
+	],
 	"contributes": {
 		"configurationDefaults": {
 			"[applescript]": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       typescript-eslint:
         specifier: ^8.31.1
         version: 8.31.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@20.17.31)(jiti@2.4.2)
 
 packages:
 
@@ -216,6 +219,162 @@ packages:
 
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.6.1':
     resolution: {integrity: sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==}
@@ -498,14 +657,123 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.10-commit.87188ed':
     resolution: {integrity: sha512-IjVRLSxjO7EzlW4S6O8AoWbCkEi1lOpE30G8Xw5ZK/zl39K/KjzsDPc1AwhftepueQnQHJMgZZG9ITEmxcF5/A==}
 
+  '@rollup/rollup-android-arm-eabi@4.46.2':
+    resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.46.2':
+    resolution: {integrity: sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.46.2':
+    resolution: {integrity: sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.46.2':
+    resolution: {integrity: sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.46.2':
+    resolution: {integrity: sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.46.2':
+    resolution: {integrity: sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+    resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
+    resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.46.2':
+    resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.46.2':
+    resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
+    resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
+    resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+    resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.46.2':
+    resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.46.2':
+    resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.46.2':
+    resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.46.2':
+    resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.46.2':
+    resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.46.2':
+    resolution: {integrity: sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.46.2':
+    resolution: {integrity: sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==}
+    cpu: [x64]
+    os: [win32]
+
   '@total-typescript/tsconfig@1.0.4':
     resolution: {integrity: sha512-fO4ctMPGz1kOFOQ4RCPBRBfMy3gDn+pegUfrGyUFRMv/Rd0ZM3/SHH3hFCYG4u6bPLG8OlmOGcBLDexvyr3A5w==}
+
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -566,6 +834,35 @@ packages:
     resolution: {integrity: sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -616,6 +913,10 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.1.0:
     resolution: {integrity: sha512-ROM2LlXbZBZVk97crfw8PGDOBzzsJvN2uJCmwswvPUNyfH14eg90mSN3xNqsri1JS1G9cz0VzeDUhxJkTrr4Ew==}
     engines: {node: '>=20.18.0'}
@@ -648,6 +949,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.2.1:
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -655,6 +960,10 @@ packages:
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -753,6 +1062,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -804,6 +1117,14 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -850,9 +1171,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -875,6 +1203,15 @@ packages:
 
   fdir@6.4.5:
     resolution: {integrity: sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -907,6 +1244,11 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1024,6 +1366,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -1189,9 +1534,15 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  loupe@3.2.0:
+    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
+
   lru-cache@11.1.0:
     resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -1225,6 +1576,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1282,6 +1638,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1292,6 +1652,14 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1351,6 +1719,11 @@ packages:
     resolution: {integrity: sha512-D+iim+DHIwK9kbZvubENmtnYFqHfFV0OKwzT8yU/W+xyUK1A71+iRFmJYBGqNUo3fJ2Ob4oIQfan63mhzh614A==}
     hasBin: true
 
+  rollup@4.46.2:
+    resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1388,6 +1761,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1398,9 +1774,19 @@ packages:
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1422,6 +1808,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1437,6 +1826,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -1446,6 +1838,18 @@ packages:
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1515,12 +1919,90 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.1.2:
+    resolution: {integrity: sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-get-config@0.4.0:
     resolution: {integrity: sha512-E51wkg214llx2fAyTum0o1vkxUIBz6CAoirXFnlL8oWgDhYm7qbBOk9CMTJomXjQu3Kvun+zuRBHckfUVpC7ow==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1737,6 +2219,84 @@ snapshots:
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.6.1(eslint@9.24.0(jiti@2.4.2))':
@@ -1964,13 +2524,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.10-commit.87188ed': {}
 
+  '@rollup/rollup-android-arm-eabi@4.46.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.46.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.46.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.46.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.46.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.46.2':
+    optional: true
+
   '@total-typescript/tsconfig@1.0.4': {}
+
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 20.17.31
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.7': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -2059,6 +2687,48 @@ snapshots:
       '@typescript-eslint/types': 8.31.1
       eslint-visitor-keys: 4.2.0
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@20.17.31)(jiti@2.4.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.1.2(@types/node@20.17.31)(jiti@2.4.2)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.0
+      tinyrainbow: 2.0.0
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -2102,6 +2772,8 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.1.0:
     dependencies:
       '@babel/parser': 7.27.4
@@ -2133,12 +2805,22 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.2.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.0
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.4.1: {}
+
+  check-error@2.1.1: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -2236,6 +2918,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   defu@6.1.4: {}
@@ -2268,6 +2952,37 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.9:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -2294,7 +3009,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -2339,7 +3054,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
+
   esutils@2.0.3: {}
+
+  expect-type@1.2.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2364,6 +3085,10 @@ snapshots:
   fdir@6.4.5(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -2395,6 +3120,9 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -2487,6 +3215,8 @@ snapshots:
   jiti@2.4.2: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -2628,7 +3358,13 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  loupe@3.2.0: {}
+
   lru-cache@11.1.0: {}
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   meow@12.1.1: {}
 
@@ -2656,6 +3392,8 @@ snapshots:
   minipass@7.1.2: {}
 
   ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -2714,11 +3452,21 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -2779,6 +3527,32 @@ snapshots:
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.10-commit.87188ed
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.10-commit.87188ed
 
+  rollup@4.46.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.46.2
+      '@rollup/rollup-android-arm64': 4.46.2
+      '@rollup/rollup-darwin-arm64': 4.46.2
+      '@rollup/rollup-darwin-x64': 4.46.2
+      '@rollup/rollup-freebsd-arm64': 4.46.2
+      '@rollup/rollup-freebsd-x64': 4.46.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.46.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.46.2
+      '@rollup/rollup-linux-arm64-gnu': 4.46.2
+      '@rollup/rollup-linux-arm64-musl': 4.46.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.46.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.46.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.46.2
+      '@rollup/rollup-linux-riscv64-musl': 4.46.2
+      '@rollup/rollup-linux-s390x-gnu': 4.46.2
+      '@rollup/rollup-linux-x64-gnu': 4.46.2
+      '@rollup/rollup-linux-x64-musl': 4.46.2
+      '@rollup/rollup-win32-arm64-msvc': 4.46.2
+      '@rollup/rollup-win32-ia32-msvc': 4.46.2
+      '@rollup/rollup-win32-x64-msvc': 4.46.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -2834,6 +3608,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.2:
@@ -2842,7 +3618,13 @@ snapshots:
 
   sliced@1.0.1: {}
 
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2866,6 +3648,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -2878,6 +3664,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.1: {}
@@ -2886,6 +3674,12 @@ snapshots:
     dependencies:
       fdir: 6.4.5(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -2952,6 +3746,81 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite-node@3.2.4(@types/node@20.17.31)(jiti@2.4.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.2(@types/node@20.17.31)(jiti@2.4.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.1.2(@types/node@20.17.31)(jiti@2.4.2):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.46.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 20.17.31
+      fsevents: 2.3.3
+      jiti: 2.4.2
+
+  vitest@3.2.4(@types/node@20.17.31)(jiti@2.4.2):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@20.17.31)(jiti@2.4.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.2(@types/node@20.17.31)(jiti@2.4.2)
+      vite-node: 3.2.4(@types/node@20.17.31)(jiti@2.4.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.31
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vscode-get-config@0.4.0:
     dependencies:
       core-js: 3.41.0
@@ -2960,6 +3829,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,8 @@
-import {
-	DocumentSymbol,
-	type DocumentSymbolProvider,
-	type ExtensionContext,
-	Range,
-	SymbolKind,
-	commands,
-	languages,
-} from 'vscode';
+import { type ExtensionContext, commands, languages } from 'vscode';
 import { osacompile, osascript } from './osa.ts';
+import { appleScriptSymbolProvider, jxaSymbolProvider } from './outline.ts';
 import { pick } from './processes.ts';
 import { createBuildTask } from './task.ts';
-
-const handlerSymbolProvider: DocumentSymbolProvider = {
-	provideDocumentSymbols(document) {
-		const text = document.getText();
-		const regex = /^\s*(?:on|to)\s+(\w+)/gm;
-		const matches: Array<{ name: string; index: number }> = [];
-		let match: RegExpExecArray | null = regex.exec(text);
-
-		while (match !== null) {
-			matches.push({ name: match[1], index: match.index });
-			match = regex.exec(text);
-		}
-
-		return matches.map((current, index) => {
-			const start = document.positionAt(current.index);
-			const endIndex = index + 1 < matches.length ? matches[index + 1].index : text.length;
-			const end = document.positionAt(endIndex);
-
-			return new DocumentSymbol(current.name, '', SymbolKind.Function, new Range(start, end), new Range(start, start));
-		});
-	},
-};
 
 async function activate(context: ExtensionContext): Promise<void> {
 	context.subscriptions.push(
@@ -97,7 +68,8 @@ async function activate(context: ExtensionContext): Promise<void> {
 			await pick();
 		}),
 
-		languages.registerDocumentSymbolProvider({ language: 'applescript' }, handlerSymbolProvider),
+		languages.registerDocumentSymbolProvider({ language: 'applescript' }, appleScriptSymbolProvider),
+		languages.registerDocumentSymbolProvider({ language: 'jxa' }, jxaSymbolProvider),
 	);
 }
 

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -1,0 +1,661 @@
+import {
+	DocumentSymbol,
+	type DocumentSymbolProvider,
+	Range,
+	type SymbolInformation,
+	SymbolKind,
+	type TextDocument,
+	commands,
+	workspace,
+} from 'vscode';
+
+/**
+ * Parse handler and tell blocks from a document using a stack-based scanner.
+ */
+export function parseFunctionBlocks(document: TextDocument) {
+	const blockOpeners = ['if', 'repeat', 'try', 'considering', 'ignoring', 'using terms', 'with timeout'] as const;
+	const blockEndQualifiers = ['try', 'if', 'repeat', 'considering', 'ignoring', 'using terms', 'timeout'] as const;
+	const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	// The helper implementations are exported above.
+	// Build a regex for block openers used by the scanner
+	const blockOpenRe = new RegExp(`^\\s*(?:${blockOpeners.map(escapeRegex).join('|')})\\b`, 'i');
+
+	const findLastIndex = <T>(arr: T[], pred: (t: T) => boolean): number => {
+		for (let i = arr.length - 1; i >= 0; i--) if (pred(arr[i] as T)) return i;
+		return -1;
+	};
+
+	const functionBlocks: Array<{ name: string; start: number; end: number; type: 'handler' | 'tell' }> = [];
+	const stack: Array<{ type: 'handler' | 'tell' | 'block'; name?: string; kind?: string; start: number }> = [];
+
+	for (let ln = 0; ln < document.lineCount; ln++) {
+		const lineRange = document.lineAt(ln).range;
+		const lineText = document.getText(lineRange);
+		if (/^\s*--/.test(lineText)) continue;
+		const openerHandler = /^\s*(?:on|to)\s+(\w+)/i.exec(lineText);
+		if (openerHandler) {
+			const hName = (openerHandler[1] ?? '').toLowerCase();
+			const inTry = stack.some((s) => s.type === 'block' && (s.kind ?? '') === 'try');
+			if (!(hName === 'error' && inTry)) {
+				stack.push({ type: 'handler', name: openerHandler[1] ?? '', start: document.offsetAt(lineRange.start) });
+				continue;
+			}
+		}
+		const tellOpen = /^\s*tell\s+(.*)$/i.exec(lineText);
+		if (tellOpen) {
+			const rest = (tellOpen[1] ?? '').trim();
+			const display = rest ? `tell ${rest}` : 'tell';
+			stack.push({ type: 'tell', name: display, start: document.offsetAt(lineRange.start) });
+			continue;
+		}
+		const blockOpen = blockOpenRe.exec(lineText);
+		if (blockOpen) {
+			const kind = (blockOpen[0] ?? '').trim().toLowerCase();
+			stack.push({ type: 'block', kind, start: document.offsetAt(lineRange.start) });
+			continue;
+		}
+		const endMatch = /^\s*end(?:\s+([\w\s]+))?\b/i.exec(lineText);
+		if (endMatch) {
+			const qualifier = (endMatch[1] ?? '').toLowerCase().trim();
+			const closeAndRecord = (idx: number) => {
+				const item = stack.splice(idx, 1)[0];
+				if (item && (item.type === 'handler' || item.type === 'tell')) {
+					functionBlocks.push({
+						name: item.name ?? '',
+						start: item.start,
+						end: document.offsetAt(lineRange.end),
+						type: item.type,
+					});
+				}
+			};
+
+			if (qualifier.startsWith('tell')) {
+				const idx = findLastIndex(stack, (s) => s.type === 'tell');
+				if (idx !== -1) closeAndRecord(idx);
+				else if (stack.length) closeAndRecord(stack.length - 1);
+				continue;
+			}
+			if (blockEndQualifiers.some((k) => (k === 'timeout' ? qualifier.includes('timeout') : qualifier.startsWith(k)))) {
+				const idx = findLastIndex(stack, (s) => s.type === 'block');
+				if (idx !== -1) stack.splice(idx, 1);
+				else if (stack.length) stack.pop();
+				continue;
+			}
+			if (qualifier.length > 0) {
+				const idx = findLastIndex(stack, (s) => s.type === 'handler' && (s.name ?? '').toLowerCase() === qualifier);
+				if (idx !== -1) {
+					closeAndRecord(idx);
+					continue;
+				}
+			}
+			if (stack.length) closeAndRecord(stack.length - 1);
+		}
+	}
+
+	functionBlocks.sort((a, b) => a.start - b.start);
+	return functionBlocks;
+}
+
+/**
+ * Collect property declarations (non-comment) from the document text.
+ */
+export function collectProperties(text: string, document: TextDocument, propertyRegex: RegExp) {
+	const out: Array<{ name: string; index: number }> = [];
+	let m = propertyRegex.exec(text);
+	while (m !== null) {
+		const name = m[1] ?? '';
+		const index = typeof m.index === 'number' ? m.index : 0;
+		const pos = document.positionAt(index);
+		const lt = document.lineAt(pos.line).text;
+		if (!/^\s*--/.test(lt)) out.push({ name, index });
+		m = propertyRegex.exec(text);
+	}
+	return out;
+}
+
+/**
+ * Collect variable assignments (non-comment) from the document text.
+ */
+export function collectVariables(text: string, document: TextDocument, varRegex: RegExp) {
+	const out: Array<{ name: string; index: number }> = [];
+	let m = varRegex.exec(text);
+	while (m !== null) {
+		const name = m[1] ?? '';
+		const index = typeof m.index === 'number' ? m.index : 0;
+		const pos = document.positionAt(index);
+		const lt = document.lineAt(pos.line).text;
+		if (!/^\s*--/.test(lt)) out.push({ name, index });
+		m = varRegex.exec(text);
+	}
+	return out;
+}
+
+/**
+ * Build parent/child node relationships for function/tell blocks.
+ */
+export function buildNodeTree(blocks: Array<{ name: string; start: number; end: number; type: 'handler' | 'tell' }>) {
+	const ns = blocks.map((b, i) => ({ ...b, idx: i, parent: -1 as number, children: [] as number[] }));
+	for (let i = 0; i < ns.length; i++) {
+		for (let j = i - 1; j >= 0; j--) {
+			const ni = ns[i];
+			const nj = ns[j];
+			if (!ni || !nj) continue;
+			if (nj.start <= ni.start && ni.end <= nj.end) {
+				ni.parent = j;
+				nj.children.push(i);
+				break;
+			}
+		}
+	}
+	return ns;
+}
+
+/**
+ * Remove duplicate items by name, keeping the first occurrence.
+ */
+export function dedupeByName(items: Array<{ name: string; index: number }>) {
+	const seen = new Set<string>();
+	const result: Array<{ name: string; index: number }> = [];
+	for (const it of items.sort((a, b) => a.index - b.index)) {
+		if (!seen.has(it.name)) {
+			seen.add(it.name);
+			result.push(it);
+		}
+	}
+	return result;
+}
+
+/**
+ * Collect top-level entry points from text using the provided regexes.
+ */
+export function collectEntryPoints(
+	text: string,
+	document: TextDocument,
+	entryPointRegex: RegExp,
+	handlerRanges: Array<{ start: number; end: number }>,
+	functionBlocks: Array<{ name: string; start: number; end: number; type: string }>,
+) {
+	const out: Array<{ name: string; index: number }> = [];
+	let m = entryPointRegex.exec(text);
+	while (m !== null) {
+		const name = m[1] ?? '';
+		const index = typeof m.index === 'number' ? m.index : 0;
+		const pos = document.positionAt(index);
+		const lt = document.lineAt(pos.line).text;
+		if (!/^\s*--/.test(lt)) {
+			const isTopLevel = !handlerRanges.some((r) => index > r.start && index < r.end);
+			if (isTopLevel && !functionBlocks.some((h) => h.name === name)) out.push({ name, index });
+		}
+		m = entryPointRegex.exec(text);
+	}
+	return out;
+}
+
+/**
+ * Build variable symbols belonging to a node but not inside its child nodes.
+ */
+export function makeVarSymbolsForNode(
+	nodeIdx: number,
+	nodesArr: ReturnType<typeof buildNodeTree>,
+	variablesArr: Array<{ name: string; index: number }>,
+	document: TextDocument,
+) {
+	const node = nodesArr[nodeIdx];
+	if (!node) return [] as DocumentSymbol[];
+	const childRanges = node.children
+		.map((ci) => nodesArr[ci])
+		.filter((c): c is typeof node => Boolean(c))
+		.map((c) => ({ start: c.start, end: c.end }));
+	const ownVars = variablesArr.filter(
+		(v) => v.index > node.start && v.index < node.end && !childRanges.some((r) => v.index > r.start && v.index < r.end),
+	);
+	return dedupeByName(ownVars).map((v) => {
+		const varStart = document.positionAt(v.index);
+		const varLineEnd = document.lineAt(varStart.line).range.end;
+		return new DocumentSymbol(
+			v.name,
+			'',
+			SymbolKind.Variable,
+			new Range(varStart, varLineEnd),
+			new Range(varStart, varStart),
+		);
+	});
+}
+
+/**
+ * Recursively build a DocumentSymbol for a function/tell node.
+ */
+export function makeFuncSymbol(
+	nodeIdx: number,
+	nodesArr: ReturnType<typeof buildNodeTree>,
+	variablesArr: Array<{ name: string; index: number }>,
+	document: TextDocument,
+): DocumentSymbol {
+	const node = nodesArr[nodeIdx];
+	if (!node) {
+		const p = document.positionAt(0);
+		return new DocumentSymbol('unknown', '', SymbolKind.Function, new Range(p, p), new Range(p, p));
+	}
+	const start = document.positionAt(node.start);
+	const end = document.positionAt(node.end);
+	const sym = new DocumentSymbol(node.name, '', SymbolKind.Function, new Range(start, end), new Range(start, start));
+	const childFuncSyms = node.children.map((ci) => makeFuncSymbol(ci, nodesArr, variablesArr, document));
+	const varSyms = makeVarSymbolsForNode(nodeIdx, nodesArr, variablesArr, document);
+	sym.children = [...childFuncSyms, ...varSyms];
+	return sym;
+}
+
+/**
+ * Emit final DocumentSymbol array from collected pieces.
+ */
+export function emitSymbols(
+	document: TextDocument,
+	properties: Array<{ name: string; index: number }>,
+	variables: Array<{ name: string; index: number }>,
+	entryPoints: Array<{ name: string; index: number }>,
+	nodes: ReturnType<typeof buildNodeTree>,
+) {
+	const out: DocumentSymbol[] = [];
+	for (const p of properties) {
+		const propStart = document.positionAt(p.index);
+		const propLineEnd = document.lineAt(propStart.line).range.end;
+		out.push(
+			new DocumentSymbol(
+				p.name,
+				'',
+				SymbolKind.Property,
+				new Range(propStart, propLineEnd),
+				new Range(propStart, propStart),
+			),
+		);
+	}
+	const handlerRanges = nodes.map((n) => ({ start: n.start, end: n.end }));
+	const globals = variables.filter((v) => !handlerRanges.some((r) => v.index > r.start && v.index < r.end));
+	for (const v of dedupeByName(globals)) {
+		const varStart = document.positionAt(v.index);
+		const varLineEnd = document.lineAt(varStart.line).range.end;
+		out.push(
+			new DocumentSymbol(
+				v.name,
+				'',
+				SymbolKind.Variable,
+				new Range(varStart, varLineEnd),
+				new Range(varStart, varStart),
+			),
+		);
+	}
+	for (const e of entryPoints) {
+		const entryStart = document.positionAt(e.index);
+		const entryLineEnd = document.lineAt(entryStart.line).range.end;
+		out.push(
+			new DocumentSymbol(
+				e.name,
+				'',
+				SymbolKind.Event,
+				new Range(entryStart, entryLineEnd),
+				new Range(entryStart, entryStart),
+			),
+		);
+	}
+	for (let i = 0; i < nodes.length; i++) {
+		if (nodes[i]?.parent === -1) out.push(makeFuncSymbol(i, nodes, variables, document));
+	}
+	return out;
+}
+
+// AppleScript Document Symbol Provider (Outline)
+export const appleScriptSymbolProvider: DocumentSymbolProvider = {
+	provideDocumentSymbols(document) {
+		const text = document.getText();
+		const propertyRegex = /^\s*property\s+(\w+)\s*:/gm;
+		// Allow bare calls with or without parentheses, e.g. myHandler or myHandler()
+		const entryPointRegex = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(\s*\))?\s*$/gm;
+		const varRegex = /^\s*set\s+(\w+)\s+to\b/gm;
+
+		// Centralize AppleScript block keywords
+		const blockOpeners = ['if', 'repeat', 'try', 'considering', 'ignoring', 'using terms', 'with timeout'] as const;
+		// For "end" lines, AppleScript uses e.g. "end timeout" rather than "end with timeout"
+		const blockEndQualifiers = ['try', 'if', 'repeat', 'considering', 'ignoring', 'using terms', 'timeout'] as const;
+
+		const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const blockOpenRe = new RegExp(`^\\s*(?:${blockOpeners.map(escapeRegex).join('|')})\\b`, 'i');
+
+		// Helpers
+		const findLastIndex = <T>(arr: T[], pred: (t: T) => boolean): number => {
+			for (let i = arr.length - 1; i >= 0; i--) if (pred(arr[i] as T)) return i;
+			return -1;
+		};
+		const isCommentAtOffset = (offset: number): boolean => {
+			const pos = document.positionAt(offset);
+			const lt = document.lineAt(pos.line).text;
+			return /^\s*--/.test(lt);
+		};
+
+		// Build function/tell blocks using a stack-based line scanner for accurate ranges
+		const parseFunctionBlocks = (): Array<{ name: string; start: number; end: number; type: 'handler' | 'tell' }> => {
+			const functionBlocks: Array<{ name: string; start: number; end: number; type: 'handler' | 'tell' }> = [];
+			const stack: Array<{ type: 'handler' | 'tell' | 'block'; name?: string; kind?: string; start: number }> = [];
+			for (let ln = 0; ln < document.lineCount; ln++) {
+				const lineRange = document.lineAt(ln).range;
+				const lineText = document.getText(lineRange);
+				// Skip line comments
+				if (/^\s*--/.test(lineText)) {
+					continue;
+				}
+				const openerHandler = /^\s*(?:on|to)\s+(\w+)/i.exec(lineText);
+				if (openerHandler) {
+					const hName = (openerHandler[1] ?? '').toLowerCase();
+					// Skip 'on error' inside a try-block; it's not a standalone handler, but part of 'try...on error...end try'
+					const inTry = stack.some((s) => s.type === 'block' && (s.kind ?? '') === 'try');
+					if (hName === 'error' && inTry) {
+						// Do not treat as a handler
+					} else {
+						stack.push({ type: 'handler', name: openerHandler[1] ?? '', start: document.offsetAt(lineRange.start) });
+						continue;
+					}
+				}
+				const tellOpen = /^\s*tell\s+(.*)$/i.exec(lineText);
+				if (tellOpen) {
+					const rest = (tellOpen[1] ?? '').trim();
+					const display = rest ? `tell ${rest}` : 'tell';
+					stack.push({ type: 'tell', name: display, start: document.offsetAt(lineRange.start) });
+					continue;
+				}
+				const blockOpen = blockOpenRe.exec(lineText);
+				if (blockOpen) {
+					const kind = (blockOpen[0] ?? '').trim().toLowerCase();
+					stack.push({ type: 'block', kind, start: document.offsetAt(lineRange.start) });
+					continue;
+				}
+				const endMatch = /^\s*end(?:\s+([\w\s]+))?\b/i.exec(lineText);
+				if (endMatch) {
+					const qualifier = (endMatch[1] ?? '').toLowerCase().trim();
+					const closeAndRecord = (idx: number) => {
+						const item = stack.splice(idx, 1)[0];
+						if (item && (item.type === 'handler' || item.type === 'tell')) {
+							functionBlocks.push({
+								name: item.name ?? '',
+								start: item.start,
+								end: document.offsetAt(lineRange.end),
+								type: item.type,
+							});
+						}
+					};
+
+					if (qualifier.startsWith('tell')) {
+						const idx = findLastIndex(stack, (s) => s.type === 'tell');
+						if (idx !== -1) closeAndRecord(idx);
+						else if (stack.length) closeAndRecord(stack.length - 1);
+						continue;
+					}
+					if (
+						blockEndQualifiers.some((k) => (k === 'timeout' ? qualifier.includes('timeout') : qualifier.startsWith(k)))
+					) {
+						const idx = findLastIndex(stack, (s) => s.type === 'block');
+						if (idx !== -1) stack.splice(idx, 1);
+						else if (stack.length) stack.pop();
+						continue;
+					}
+					if (qualifier.length > 0) {
+						const idx = findLastIndex(stack, (s) => s.type === 'handler' && (s.name ?? '').toLowerCase() === qualifier);
+						if (idx !== -1) {
+							closeAndRecord(idx);
+							continue;
+						}
+					}
+					// Plain 'end' fallback
+					if (stack.length) closeAndRecord(stack.length - 1);
+				}
+			}
+			// Sort by start position
+			functionBlocks.sort((a, b) => a.start - b.start);
+			return functionBlocks;
+		};
+		const functionBlocks = parseFunctionBlocks();
+
+		// Collect property declarations
+		const collectProperties = (): Array<{ name: string; index: number }> => {
+			const out: Array<{ name: string; index: number }> = [];
+			let m = propertyRegex.exec(text);
+			while (m !== null) {
+				const name = m[1] ?? '';
+				const index = typeof m.index === 'number' ? m.index : 0;
+				if (!isCommentAtOffset(index)) out.push({ name, index });
+				m = propertyRegex.exec(text);
+			}
+			return out;
+		};
+		const properties = collectProperties();
+
+		// Collect variable assignments
+		const collectVariables = (): Array<{ name: string; index: number }> => {
+			const out: Array<{ name: string; index: number }> = [];
+			let m = varRegex.exec(text);
+			while (m !== null) {
+				const name = m[1] ?? '';
+				const index = typeof m.index === 'number' ? m.index : 0;
+				if (!isCommentAtOffset(index)) out.push({ name, index });
+				m = varRegex.exec(text);
+			}
+			return out;
+		};
+		const variables = collectVariables();
+
+		// Build symbols, nesting variables under their handler, and add global variables as top-level
+		const handlerRanges: Array<{ start: number; end: number }> = functionBlocks.map((b) => ({
+			start: b.start,
+			end: b.end,
+		}));
+
+		// Build a tree of function/tell blocks (parent-child relations)
+		const buildNodeTree = (blocks: Array<{ name: string; start: number; end: number; type: 'handler' | 'tell' }>) => {
+			const ns = blocks.map((b, i) => ({ ...b, idx: i, parent: -1 as number, children: [] as number[] }));
+			for (let i = 0; i < ns.length; i++) {
+				for (let j = i - 1; j >= 0; j--) {
+					const ni = ns[i];
+					const nj = ns[j];
+					if (!ni || !nj) continue;
+					if (nj.start <= ni.start && ni.end <= nj.end) {
+						ni.parent = j;
+						nj.children.push(i);
+						break;
+					}
+				}
+			}
+			return ns;
+		};
+		const nodes = buildNodeTree(functionBlocks);
+
+		// Helper: dedupe by variable name, keeping first occurrence
+		const dedupeByName = (items: Array<{ name: string; index: number }>) => {
+			const seen = new Set<string>();
+			const result: Array<{ name: string; index: number }> = [];
+			for (const it of items.sort((a, b) => a.index - b.index)) {
+				if (!seen.has(it.name)) {
+					seen.add(it.name);
+					result.push(it);
+				}
+			}
+			return result;
+		};
+
+		/**
+		 * Collect top-level entry points (bare calls) that are not inside handlers.
+		 */
+		const collectEntryPoints = (): Array<{ name: string; index: number }> => {
+			const out: Array<{ name: string; index: number }> = [];
+			let m = entryPointRegex.exec(text);
+			while (m !== null) {
+				const name = m[1] ?? '';
+				const index = typeof m.index === 'number' ? m.index : 0;
+				if (!isCommentAtOffset(index)) {
+					const isTopLevel = !handlerRanges.some((r) => index > r.start && index < r.end);
+					if (isTopLevel && !functionBlocks.some((h) => h.name === name)) out.push({ name, index });
+				}
+				m = entryPointRegex.exec(text);
+			}
+			return out;
+		};
+		const entryPoints = collectEntryPoints();
+
+		/**
+		 * Emit final DocumentSymbol array from collected pieces.
+		 */
+		const emitSymbols = () => {
+			const out: DocumentSymbol[] = [];
+
+			// properties
+			for (const p of properties) {
+				const propStart = document.positionAt(p.index);
+				const propLineEnd = document.lineAt(propStart.line).range.end;
+				out.push(
+					new DocumentSymbol(
+						p.name,
+						'',
+						SymbolKind.Property,
+						new Range(propStart, propLineEnd),
+						new Range(propStart, propStart),
+					),
+				);
+			}
+
+			// globals
+			const globals = variables.filter((v) => !handlerRanges.some((r) => v.index > r.start && v.index < r.end));
+			for (const v of dedupeByName(globals)) {
+				const varStart = document.positionAt(v.index);
+				const varLineEnd = document.lineAt(varStart.line).range.end;
+				out.push(
+					new DocumentSymbol(
+						v.name,
+						'',
+						SymbolKind.Variable,
+						new Range(varStart, varLineEnd),
+						new Range(varStart, varStart),
+					),
+				);
+			}
+
+			// entry points
+			for (const e of entryPoints) {
+				const entryStart = document.positionAt(e.index);
+				const entryLineEnd = document.lineAt(entryStart.line).range.end;
+				out.push(
+					new DocumentSymbol(
+						e.name,
+						'',
+						SymbolKind.Event,
+						new Range(entryStart, entryLineEnd),
+						new Range(entryStart, entryStart),
+					),
+				);
+			}
+
+			// functions/tells
+			for (let i = 0; i < nodes.length; i++) {
+				if (nodes[i]?.parent === -1) {
+					out.push(makeFuncSymbol(i, nodes, variables));
+				}
+			}
+
+			return out;
+		};
+
+		const symbols = emitSymbols();
+
+		// Helper: build variable symbols belonging to a node but not inside its child nodes
+		function makeVarSymbolsForNode(
+			nodeIdx: number,
+			nodesArr: typeof nodes,
+			variablesArr: Array<{ name: string; index: number }>,
+		) {
+			const node = nodesArr[nodeIdx];
+			if (!node) return [] as DocumentSymbol[];
+			const childRanges = node.children
+				.map((ci) => nodesArr[ci])
+				.filter((c): c is typeof node => Boolean(c))
+				.map((c) => ({ start: c.start, end: c.end }));
+			const ownVars = variablesArr.filter(
+				(v) =>
+					v.index > node.start && v.index < node.end && !childRanges.some((r) => v.index > r.start && v.index < r.end),
+			);
+			return dedupeByName(ownVars).map((v) => {
+				const varStart = document.positionAt(v.index);
+				const varLineEnd = document.lineAt(varStart.line).range.end;
+				return new DocumentSymbol(
+					v.name,
+					'',
+					SymbolKind.Variable,
+					new Range(varStart, varLineEnd),
+					new Range(varStart, varStart),
+				);
+			});
+		}
+
+		// Recursively build function/tell symbols tree (pure helper)
+		function makeFuncSymbol(
+			nodeIdx: number,
+			nodesArr: typeof nodes,
+			variablesArr: Array<{ name: string; index: number }>,
+		): DocumentSymbol {
+			const node = nodesArr[nodeIdx];
+			if (!node) {
+				const p = document.positionAt(0);
+				return new DocumentSymbol('unknown', '', SymbolKind.Function, new Range(p, p), new Range(p, p));
+			}
+			const start = document.positionAt(node.start);
+			const end = document.positionAt(node.end);
+			const sym = new DocumentSymbol(
+				node.name,
+				'',
+				SymbolKind.Function,
+				new Range(start, end),
+				new Range(start, start),
+			);
+			const childFuncSyms = node.children.map((ci) => makeFuncSymbol(ci, nodesArr, variablesArr));
+			const varSyms = makeVarSymbolsForNode(nodeIdx, nodesArr, variablesArr);
+			sym.children = [...childFuncSyms, ...varSyms];
+			return sym;
+		}
+
+		// Add top-level function/tell symbols
+		for (let i = 0; i < nodes.length; i++) {
+			if (nodes[i]?.parent === -1) {
+				symbols.push(makeFuncSymbol(i, nodes, variables));
+			}
+		}
+		if (!Array.isArray(symbols)) {
+			return [];
+		}
+		return symbols.filter((s) => s instanceof DocumentSymbol);
+	},
+};
+
+// JXA: delegate to JavaScript's outline by creating a virtual JS document with identical content
+export const jxaSymbolProvider: DocumentSymbolProvider = {
+	async provideDocumentSymbols(document) {
+		const text = document.getText();
+		const jsDoc = await workspace.openTextDocument({ language: 'javascript', content: text });
+		const result = await commands.executeCommand<(DocumentSymbol | SymbolInformation)[] | undefined>(
+			'vscode.executeDocumentSymbolProvider',
+			jsDoc.uri,
+		);
+		if (!Array.isArray(result) || result.length === 0) return [];
+		// If already DocumentSymbols (presence of selectionRange), return as-is
+		const first = result[0] as DocumentSymbol | SymbolInformation;
+		if ((first as DocumentSymbol).selectionRange !== undefined) {
+			return result as DocumentSymbol[];
+		}
+		// Convert SymbolInformation[] to DocumentSymbol[] (flat)
+		const infos = result as SymbolInformation[];
+		return infos.map((s) => {
+			const range = s.location.range;
+			return new DocumentSymbol(
+				s.name ?? '',
+				s.containerName ?? '',
+				s.kind ?? SymbolKind.Function,
+				range,
+				new Range(range.start, range.start),
+			);
+		});
+	},
+};

--- a/test/outline.more.test.ts
+++ b/test/outline.more.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { Range, SymbolKind } from 'vscode';
+import type { TextDocument } from 'vscode';
+import {
+	buildNodeTree,
+	collectEntryPoints,
+	collectProperties,
+	collectVariables,
+	dedupeByName,
+	emitSymbols,
+	makeFuncSymbol,
+	makeVarSymbolsForNode,
+	parseFunctionBlocks,
+} from '../src/outline.ts';
+import { makeDoc } from './util.ts';
+
+const propertyRe = /^\s*property\s+(\w+)\s*:/gm;
+const varRe = /^\s*set\s+(\w+)\s+to\b/gm;
+const entryRe = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(\s*\))?\s*$/gm;
+
+describe('helpers - properties, entry points, tree, and emission', () => {
+	it('collectProperties ignores commented lines', () => {
+		const text = 'property foo: 1\n-- property bar: 2\nproperty baz: 3';
+		const doc = makeDoc(text);
+		const props = collectProperties(text, doc as TextDocument, propertyRe);
+		expect(props.map((p) => p.name)).toEqual(['foo', 'baz']);
+	});
+
+	it('dedupeByName keeps first occurrence', () => {
+		const items = [
+			{ name: 'a', index: 1 },
+			{ name: 'b', index: 2 },
+			{ name: 'a', index: 3 },
+		];
+		const out = dedupeByName(items);
+		expect(out).toEqual([
+			{ name: 'a', index: 1 },
+			{ name: 'b', index: 2 },
+		]);
+	});
+
+	it('buildNodeTree nests child handlers inside tell blocks', () => {
+		const doc = makeDoc('tell app "Notes"\n  on inner()\n  end inner\nend tell\n\non top()\nend top');
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		const nodes = buildNodeTree(blocks);
+		const names = nodes.map((n) => n.name);
+		expect(names).toContain('tell app "Notes"');
+		const tellIdx = nodes.findIndex((n) => n.name.startsWith('tell'));
+		const innerIdx = nodes.findIndex((n) => n.name === 'inner');
+		expect(tellIdx).toBeGreaterThanOrEqual(0);
+		expect(innerIdx).toBeGreaterThanOrEqual(0);
+		expect(nodes[innerIdx]?.parent).toBe(tellIdx);
+		const topIdx = nodes.findIndex((n) => n.name === 'top');
+		expect(nodes[topIdx]?.parent).toBe(-1);
+	});
+
+	it('collectEntryPoints finds top-level bare calls and skips inside handlers or duplicates', () => {
+		const text = 'on foo()\nend foo\n\nfoo()\nbar\n\n on baz()\n  bar\n end baz';
+		const doc = makeDoc(text);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		const handlerRanges = blocks.map((b) => ({ start: b.start, end: b.end }));
+		const entries = collectEntryPoints(text, doc as TextDocument, entryRe, handlerRanges, blocks);
+		expect(entries.map((e) => e.name)).toEqual(['bar']);
+	});
+
+	it('makeVarSymbolsForNode excludes vars from child handlers and dedupes', () => {
+		const text = 'on outer()\n  set x to 1\n  set y to 2\n  on inner()\n    set x to 3\n  end inner\nend outer';
+		const doc = makeDoc(text);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		const nodes = buildNodeTree(blocks);
+		const vars = collectVariables(text, doc as TextDocument, varRe);
+		const outerIdx = nodes.findIndex((n) => n.name === 'outer');
+		const syms = makeVarSymbolsForNode(
+			outerIdx,
+			nodes as unknown as ReturnType<typeof buildNodeTree>,
+			vars,
+			doc as TextDocument,
+		);
+		expect(syms.map((s) => s.name)).toEqual(['x', 'y']);
+		expect(syms.every((s) => s.kind === SymbolKind.Variable)).toBe(true);
+	});
+
+	it('emitSymbols integrates properties, globals, entry points, and functions', () => {
+		const text = 'property p: 1\nset g to 0\n\non h()\n  set v to 1\nend h\n\nbar';
+		const doc = makeDoc(text);
+		const props = collectProperties(text, doc as TextDocument, propertyRe);
+		const vars = collectVariables(text, doc as TextDocument, varRe);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		const nodes = buildNodeTree(blocks);
+		const handlerRanges = blocks.map((b) => ({ start: b.start, end: b.end }));
+		const entries = collectEntryPoints(text, doc as TextDocument, entryRe, handlerRanges, blocks);
+
+		const symbols = emitSymbols(doc as TextDocument, props, vars, entries, nodes);
+		const kinds = symbols.reduce((acc: Record<number, number>, s) => {
+			acc[s.kind] = (acc[s.kind] || 0) + 1;
+			return acc;
+		}, {});
+		// Expect: 1 property, 1 global var, 1 event, 1 function
+		expect(kinds[SymbolKind.Property]).toBe(1);
+		expect(kinds[SymbolKind.Variable]).toBeGreaterThanOrEqual(1);
+		expect(kinds[SymbolKind.Event]).toBe(1);
+		expect(kinds[SymbolKind.Function]).toBeGreaterThanOrEqual(1);
+
+		const h = symbols.find((s) => s.name === 'h');
+		expect(h).toBeTruthy();
+		expect(h?.children.some((c) => c.kind === SymbolKind.Variable && c.name === 'v')).toBe(true);
+	});
+
+	it('recognizes "to" handlers and supports plain end fallback for blocks', () => {
+		const text = 'to calc(x)\n  if x > 1 then\n    set y to 2\n  end\nend calc';
+		const doc = makeDoc(text);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		expect(blocks.map((b) => b.name)).toEqual(['calc']);
+	});
+
+	it('handles "using terms" and "with timeout" blocks without creating symbols', () => {
+		const text =
+			'on outer()\n  using terms from application "System Events"\n    with timeout of 5 seconds\n      set a to 1\n    end timeout\n  end using terms from\nend outer';
+		const doc = makeDoc(text);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		// Only the handler should be recorded, not the generic blocks
+		expect(blocks.length).toBe(1);
+		expect(blocks[0]?.name).toBe('outer');
+	});
+
+	it('closes tell with qualified end tell application "X"', () => {
+		const text = 'tell application "Notes"\n  set a to 1\nend tell application "Notes"';
+		const doc = makeDoc(text);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		expect(blocks.length).toBe(1);
+		expect(blocks[0]?.name).toBe('tell application "Notes"');
+	});
+
+	it("treats 'on error' outside try as a handler", () => {
+		const text = 'on error m number n\nend error';
+		const doc = makeDoc(text);
+		const blocks = parseFunctionBlocks(doc as TextDocument);
+		expect(blocks.length).toBe(1);
+		expect(blocks[0]?.name.toLowerCase()).toBe('error');
+	});
+});

--- a/test/outline.test.ts
+++ b/test/outline.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { collectVariables, parseFunctionBlocks } from '../src/outline.ts';
+import { makeDoc } from './util.ts';
+
+describe('outline helpers', () => {
+	it('parses handlers and tell blocks', () => {
+		const doc = makeDoc(
+			'on foo()\n  set x to 1\nend foo\n\n\ntell application "Notes"\n  on bar()\n    set y to 2\n  end bar\nend tell',
+		);
+		const blocks = parseFunctionBlocks(doc);
+		const names = blocks.map((b) => b.name);
+		expect(names).toContain('foo');
+		expect(names).toContain('tell application "Notes"');
+		expect(names).toContain('bar');
+	});
+
+	it('collects variable assignments and ignores comments', () => {
+		const text = 'set a to 1\n-- set ignored to 9\nset b to 2';
+		const doc = makeDoc(text);
+		const vars = collectVariables(text, doc, /^\s*set\s+(\w+)\s+to\b/gm);
+		expect(vars.map((v) => v.name)).toEqual(['a', 'b']);
+	});
+
+	it("doesn't treat 'on error' inside try as a handler", () => {
+		const doc = makeDoc('try\n  on error m number n\nend try');
+		const blocks = parseFunctionBlocks(doc);
+		expect(blocks.length).toBe(0);
+	});
+});

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CancellationToken, TextDocument } from 'vscode';
+import { appleScriptSymbolProvider, jxaSymbolProvider } from '../src/outline.ts';
+import { makeDoc } from './util.ts';
+import { DocumentSymbol, Range, SymbolKind, commands, workspace } from './vscode-stub';
+
+// Restore original stubs after tests
+const origExec = commands.executeCommand;
+const origOpen = workspace.openTextDocument;
+
+describe('providers', () => {
+	afterEach(() => {
+		(commands as unknown as { executeCommand: (...args: unknown[]) => Promise<unknown[]> }).executeCommand = origExec;
+		(workspace as unknown as { openTextDocument: () => Promise<{ uri: { fsPath: string } }> }).openTextDocument =
+			origOpen;
+	});
+
+	it('appleScriptSymbolProvider returns symbols end-to-end', async () => {
+		const text =
+			'property a: 1\nset g to 0\n\n-- comment\non run()\n  set x to 1\nend run\n\ntell app "Finder"\n  on inside()\n    set y to 2\n  end inside\nend tell\n\nlaunch';
+		const doc = makeDoc(text);
+		const symbols =
+			(await appleScriptSymbolProvider.provideDocumentSymbols(
+				doc as unknown as TextDocument,
+				null as unknown as CancellationToken,
+			)) ?? [];
+		expect(Array.isArray(symbols)).toBe(true);
+		// top-level contains property, global var, event, and function/tell
+		const names = (symbols as DocumentSymbol[]).map((s) => s.name);
+		expect(names).toContain('a');
+		expect(names).toContain('g');
+		expect(names).toContain('launch');
+		expect(names.some((n: string) => n.startsWith('tell'))).toBe(true);
+	});
+
+	it('jxaSymbolProvider passes through DocumentSymbols unchanged', async () => {
+		const pos = { line: 0, character: 0 };
+		const r = new Range(pos, pos);
+		const fake = [new DocumentSymbol('f', '', SymbolKind.Function, r, r)];
+		(workspace as unknown as { openTextDocument: () => Promise<{ uri: { fsPath: string } }> }).openTextDocument =
+			async () => ({ uri: { fsPath: '' } });
+		(commands as unknown as { executeCommand: (...args: unknown[]) => Promise<unknown[]> }).executeCommand = async () =>
+			fake as unknown[];
+		const doc = makeDoc('function f(){}');
+		const out = (await jxaSymbolProvider.provideDocumentSymbols(
+			doc as unknown as TextDocument,
+			null as unknown as CancellationToken,
+		)) as DocumentSymbol[];
+		expect(out).toEqual(fake);
+	});
+
+	it('jxaSymbolProvider converts SymbolInformation to DocumentSymbol', async () => {
+		(workspace as unknown as { openTextDocument: () => Promise<{ uri: { fsPath: string } }> }).openTextDocument =
+			async () => ({ uri: { fsPath: '' } });
+		const range = new Range({ line: 0, character: 0 }, { line: 0, character: 0 });
+		(commands as unknown as { executeCommand: (...args: unknown[]) => Promise<unknown[]> }).executeCommand =
+			async () => [{ name: 'g', containerName: 'c', kind: SymbolKind.Function, location: { range } }];
+		const doc = makeDoc('function g(){}');
+		const out = (await jxaSymbolProvider.provideDocumentSymbols(
+			doc as unknown as TextDocument,
+			null as unknown as CancellationToken,
+		)) as DocumentSymbol[];
+		expect(out?.length).toBe(1);
+		expect(out?.[0]?.name).toBe('g');
+		expect((out?.[0] as DocumentSymbol)?.detail).toBe('c');
+		expect(out?.[0]?.kind).toBe(SymbolKind.Function);
+	});
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,36 @@
+import type { TextDocument } from 'vscode';
+
+type PositionLike = { line: number; character: number };
+type Line = { range: { start: PositionLike; end: PositionLike }; text: string };
+
+export function makeDoc(text: string): TextDocument {
+	const lines = text.split(/\r?\n/);
+	return {
+		getText(range?: { start: PositionLike }) {
+			if (!range) return text;
+			const start = range.start.line;
+			return lines[start];
+		},
+		lineCount: lines.length,
+		lineAt(line: number): Line {
+			return {
+				range: { start: { line, character: 0 }, end: { line, character: lines[line]?.length ?? 0 } },
+				text: lines[line],
+			} as Line;
+		},
+		offsetAt(pos: PositionLike) {
+			let off = 0;
+			for (let i = 0; i < pos.line; i++) off += (lines[i]?.length ?? 0) + 1;
+			return off;
+		},
+		positionAt(offset: number): PositionLike {
+			let o = 0;
+			for (let i = 0; i < lines.length; i++) {
+				const l = (lines[i]?.length ?? 0) + 1;
+				if (offset < o + l) return { line: i, character: Math.max(0, offset - o) };
+				o += l;
+			}
+			return { line: lines.length - 1, character: Math.max(0, lines[lines.length - 1]?.length ?? 0) };
+		},
+	} as unknown as TextDocument;
+}

--- a/test/vscode-stub.ts
+++ b/test/vscode-stub.ts
@@ -1,0 +1,26 @@
+// Minimal VS Code API stubs for tests
+export type PositionLike = { line: number; character: number };
+export class Range {
+	constructor(
+		public start: PositionLike,
+		public end: PositionLike,
+	) {}
+}
+export class DocumentSymbol {
+	public children: DocumentSymbol[] = [];
+	constructor(
+		public name: string,
+		public detail: string,
+		public kind: number,
+		public range: Range,
+		public selectionRange: Range,
+	) {}
+}
+export const SymbolKind = {
+	Function: 11,
+	Variable: 13,
+	Property: 7,
+	Event: 24,
+} as const;
+export const commands = { executeCommand: async (): Promise<unknown[]> => [] };
+export const workspace = { openTextDocument: async () => ({ uri: { fsPath: '' } }) };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['test/**/*.test.ts'],
+	},
+	resolve: {
+		alias: [
+			{
+				find: 'vscode',
+				replacement: join(__dirname, 'test', 'vscode-stub.ts'),
+			},
+		],
+	},
+});


### PR DESCRIPTION
## Summary
- add a symbol provider to surface AppleScript handlers in the Outline view
- activate extension on AppleScript and JXA documents

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa205e0888331af9e3346b86aada7